### PR TITLE
Fix Postgres connection refused error

### DIFF
--- a/check.rb
+++ b/check.rb
@@ -24,6 +24,6 @@ begin
     })
   log pg.exec("SELECT version();").first["version"]
 rescue PG::Error => e
-  STDERR.puts("PostgreSQL connection faild")
+  STDERR.puts("PostgreSQL connection failed")
   exit 2
 end

--- a/check.sh
+++ b/check.sh
@@ -4,7 +4,7 @@ set -e
 function check_port() {
 	local host=${1} && shift
 	local port=${1} && shift
-	local retries=5
+	local retries=25
 	local wait=1
 
 	until( $(nc -zv ${host} ${port}) ); do


### PR DESCRIPTION
The project is working perfectly when using `jet`, but I was running into this error when trying to run it on Codeship Pro:

```
...
2017-02-13T22:59:06.464Zapppostgres [172.17.0.4] 5432 (postgresql) : Connection refused
2017-02-13T22:59:06.618ZappStep bash_check.sh running service app failed (1)`
```

Increasing the number of retries to 25 in the `check.sh` script fixed the issue for me. I ran the build a few times again, and I got the connection refused message about 17-20 times; then the connection to Postgres works and the build is successful.